### PR TITLE
`benchmark` を依存に追加

### DIFF
--- a/apm_traceable.gemspec
+++ b/apm_traceable.gemspec
@@ -30,4 +30,6 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
 
   spec.metadata['rubygems_mfa_required'] = 'true'
+
+  spec.add_dependency 'benchmark'
 end


### PR DESCRIPTION
Ruby 3.5 で default gem から bundled gem に移籍となるため

cf. https://github.com/ruby/ruby/blob/66c12bd5194396fab66338a87ca8f2d89f1d66d0/NEWS.md#stdlib-updates