### PR TITLE
Disable Capybara/RSpec/PredicateMatcher cop to fix RuboCop running error

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -27,3 +27,7 @@ RSpec/ExampleLength:
   Max: 20
 RSpec/NamedSubject:
   Enabled: false
+
+# Disable problematic cop that requires EnforcedStyle configuration
+Capybara/RSpec/PredicateMatcher:
+  Enabled: false


### PR DESCRIPTION
RuboCop was trying to use the `Capybara/RSpec/PredicateMatcher` cop provided by `rubocop-capybara` when running `bundle exec rubocop`. However, since `apm_traceable` doesn't include `rubocop-capybara` as a dependency, this caused an error. Disabling this cop resolves the issue.

Related issue: https://github.com/rubocop/rubocop/issues/13982